### PR TITLE
Add -march=native for compilers that support it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
 endif()
 
+check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
+if(COMPILER_SUPPORTS_MARCH_NATIVE)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+endif()
+
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     check_cxx_compiler_flag("/O2" CXX_FLAG_O2)
     check_cxx_compiler_flag("/Oy" CXX_FLAG_Oy)


### PR DESCRIPTION
Without this modification to the make file, I was not able to compile the project on my system with gcc due to the following compilation error:

```
In file included from [...]/leopard/LeopardCommon.h:257:0,
                 from [...]/leopard/LeopardFF16.h:31,
                 from [...]/leopard/LeopardFF16.cpp:29:
/usr/lib/gcc/x86_64-linux-gnu/7/include/tmmintrin.h:136:1: error: inlining failed in call to always_inline ‘__m128i _mm_shuffle_epi8(__m128i, __m128i)’: target specific option mismatch
 _mm_shuffle_epi8 (__m128i __X, __m128i __Y)
 ^~~~~~~~~~~~~~~~
```