### PR TITLE
Handle the case when no original data was lost

### DIFF
--- a/leopard.cpp
+++ b/leopard.cpp
@@ -291,7 +291,7 @@ LEO_EXPORT LeopardResult leo_decode(
     }
 
     // Handle m = 1 case
-    if (recovery_count == 1 && recovery_got_count == 1)
+    if (recovery_count == 1)
     {
         DecodeM1(
             buffer_bytes,

--- a/leopard.cpp
+++ b/leopard.cpp
@@ -283,7 +283,7 @@ LEO_EXPORT LeopardResult leo_decode(
     }
     
     // Handle case original_loss_count = 0
-    if (original_loss_count = 0)
+    if (original_loss_count == 0)
     {
         for(unsigned i = 0; i < original_count; i++)
             memcpy(work_data[i], original_data[i], buffer_bytes);

--- a/leopard.cpp
+++ b/leopard.cpp
@@ -283,7 +283,7 @@ LEO_EXPORT LeopardResult leo_decode(
     }
 
     // Handle m = 1 case
-    if (recovery_count == 1)
+    if (recovery_count == 1 && original_loss_count == 1)
     {
         DecodeM1(
             buffer_bytes,

--- a/leopard.cpp
+++ b/leopard.cpp
@@ -281,9 +281,17 @@ LEO_EXPORT LeopardResult leo_decode(
         memcpy(work_data[0], recovery_data[recovery_got_i], buffer_bytes);
         return Leopard_Success;
     }
+    
+    // Handle case original_loss_count = 0
+    if (original_loss_count = 0)
+    {
+        for(unsigned i = 0; i < original_count; i++)
+            memcpy(work_data[i], original_data[i], buffer_bytes);
+        return Leopard_Success;
+    }
 
     // Handle m = 1 case
-    if (recovery_count == 1 && original_loss_count == 1)
+    if (recovery_count == 1 && recovery_got_count == 1)
     {
         DecodeM1(
             buffer_bytes,


### PR DESCRIPTION
I ran into an edge case in my application bef where if there is no corrupted original data, but all the recoveries are corrupted, we head into a null dereference. So to handle the case where we have no lost data, we should just copy that data into the work array and return Leopard_Success. This allows me to naively call the decode library without having to check if the original array is fine or not, and I feel is an undocumented footgun anyways.