### PR TITLE
Portable builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,11 @@ endif()
 
 check_cxx_compiler_flag("-march=native" COMPILER_SUPPORTS_MARCH_NATIVE)
 if(COMPILER_SUPPORTS_MARCH_NATIVE)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    if(LEOPARD_PORTABLE_BUILD_TARGET)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=${LEOPARD_PORTABLE_BUILD_TARGET}")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=native")
+    endif()
 endif()
 
 if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")

--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ Addition in this finite field is XOR, and a vectorized memory XOR routine
 is also used.
 
 
+#### Portable builds
+
+By default if your compiler supports native CPU architecture optimization, leopard will be compiled to use the available instruction sets. This is great for performance but not portability. If you're building leopard as part of a continuous-integration pipeline, the CPU architecture of the build systems will influence the instructions used in the output binary. This can result in binaries that contain illegal instructions when running on user CPUs. (SIGILL: Illegal operation.)
+
+To prevent this, you can set the `LEOPARD_PORTABLE_BUILD_TARGET` cmake option to define the target architecture you want to build for.
+For example: `cmake . -B build -G"MSYS Makefiles" -DLEOPARD_PORTABLE_BUILD_TARGET=x86-64-v3`
+
+This allows you to build binaries that can run on any CPU that supports the selected instruction sets. Warning: Leopard relies on several instruction sets, and therefore cannot be built targetting any and all architectures your compiler may support.
+
+
 #### References:
 
 This library implements an MDS erasure code introduced in this paper:


### PR DESCRIPTION
By default leopard builds with native CPU architecture optimization. If you building leopard as part of a CI pipeline, the CPU of the build systems determine the instruction sets. The resulting binaries can contain illegal instructions for other systems, resulting in SIGILL: Illegal operation.

This PR adds a cmake option `LEOPARD_PORTABLE_BUILD_TARGET` that allows users to override the march flag if needed.
